### PR TITLE
Update actions/checkout to v4 and replace docker-compose with docker compose

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -16,21 +16,23 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build the Docker image
-      run: docker-compose build --no-cache --force-rm 
+      run: docker compose build --no-cache --force-rm
+
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Test the Docker image
-        run: docker-compose up -d 
+        run: docker compose up -d
+
   push_to_registry:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
Replaces `actions/checkout@v3` with `actions/checkout@v4` due to Node 12 deprecation
```
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```

Also replaces the [deprecated docker-compose](https://docs.docker.com/compose/releases/migrate/) with `docker compose`